### PR TITLE
Remove unused weaviate and vertex config, add evaluator model env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ OPENAI_API_KEY="..."  # Or use GEMINI_API_KEY or GOOGLE_API_KEY
 # Preview: gemini-3-pro-preview, gemini-3-flash-preview
 DEFAULT_PLANNER_MODEL="gemini-2.5-pro"
 DEFAULT_WORKER_MODEL="gemini-2.5-flash"
+DEFAULT_EVALUATOR_MODEL="gemini-2.5-pro"
 
 # LangFuse (optional, for tracing)
 LANGFUSE_SECRET_KEY="sk-lf-..."

--- a/aieng-eval-agents/aieng/agent_evals/async_client_manager.py
+++ b/aieng-eval-agents/aieng/agent_evals/async_client_manager.py
@@ -1,8 +1,7 @@
 """Async client lifecycle manager for Gradio applications.
 
 Provides idempotent initialization and proper cleanup of async clients
-like Weaviate and OpenAI to prevent event loop conflicts during Gradio's
-hot-reload process.
+like OpenAI to prevent event loop conflicts during Gradio's hot-reload process.
 """
 
 import sqlite3
@@ -111,7 +110,7 @@ class AsyncClientManager:
             The configuration instance.
         """
         if self._configs is None:
-            self._configs = Configs()  # pyright: ignore[reportCallIssue]
+            self._configs = Configs()  # type: ignore[call-arg]
         return self._configs
 
     @property

--- a/aieng-eval-agents/aieng/agent_evals/configs.py
+++ b/aieng-eval-agents/aieng/agent_evals/configs.py
@@ -42,6 +42,10 @@ class Configs(BaseSettings):
         default="gemini-2.5-flash",
         description="Model name for worker/simple tasks.",
     )
+    default_evaluator_model: str = Field(
+        default="gemini-2.5-pro",
+        description="Model name for LLM-as-judge evaluation tasks.",
+    )
 
     # === Tracing (Langfuse) ===
     langfuse_public_key: str | None = Field(
@@ -71,64 +75,6 @@ class Configs(BaseSettings):
     embedding_model_name: str = Field(
         default="@cf/baai/bge-m3",
         description="Name of the embedding model.",
-    )
-
-    # === Weaviate Vector Database ===
-    weaviate_collection_name: str = Field(
-        default="enwiki_20250520",
-        description="Name of the Weaviate collection to use.",
-    )
-    weaviate_api_key: str | None = Field(
-        default=None,
-        description="API key for Weaviate cloud instance.",
-    )
-    weaviate_http_host: str | None = Field(
-        default=None,
-        pattern=r"^.*\.weaviate\.cloud$|^localhost$",
-        description="Weaviate HTTP host (must end with .weaviate.cloud or be 'localhost').",
-    )
-    weaviate_grpc_host: str | None = Field(
-        default=None,
-        pattern=r"^grpc-.*\.weaviate\.cloud$|^localhost$",
-        description="Weaviate gRPC host (must start with 'grpc-' and end with .weaviate.cloud, or be 'localhost').",
-    )
-    weaviate_http_port: int = Field(
-        default=443,
-        description="Port for Weaviate HTTP connections.",
-    )
-    weaviate_grpc_port: int = Field(
-        default=443,
-        description="Port for Weaviate gRPC connections.",
-    )
-    weaviate_http_secure: bool = Field(
-        default=True,
-        description="Use secure HTTP connection for Weaviate.",
-    )
-    weaviate_grpc_secure: bool = Field(
-        default=True,
-        description="Use secure gRPC connection for Weaviate.",
-    )
-
-    # === Vertex AI / Google Cloud ===
-    vertex_ai_project: str | None = Field(
-        default=None,
-        validation_alias="VERTEX_AI_PROJECT",
-        description="Google Cloud project ID for Vertex AI.",
-    )
-    vertex_ai_location: str = Field(
-        default="us-central1",
-        validation_alias="VERTEX_AI_LOCATION",
-        description="Google Cloud region for Vertex AI.",
-    )
-    vector_search_index_endpoint: str | None = Field(
-        default=None,
-        validation_alias="VECTOR_SEARCH_INDEX_ENDPOINT",
-        description="Vertex AI Vector Search index endpoint.",
-    )
-    vector_search_index_id: str | None = Field(
-        default=None,
-        validation_alias="VECTOR_SEARCH_INDEX_ID",
-        description="Vertex AI Vector Search index ID.",
     )
 
     # === E2B Code Interpreter ===


### PR DESCRIPTION
- This PR removes unused weaviate config, since we decided not to use it for this bootcamp.
- I also cleaned up some unused vertex config that i added in my previous PR. My agent still doesn't use vertex, and until i actually use it, I thought its better to keep the config clean.
- Updated .env.example
- Add a separate config/env variable for evaluator model. So there is 3 now - One for the agent worker, another for planner and one for evaluator.