### PR TITLE
Rename modules to knowledge_qa

### DIFF
--- a/aieng-eval-agents/aieng/agent_evals/knowledge_qa/__init__.py
+++ b/aieng-eval-agents/aieng/agent_evals/knowledge_qa/__init__.py
@@ -5,7 +5,7 @@ question answering agents using Google ADK with explicit Google Search tool call
 
 Example
 -------
->>> from aieng.agent_evals.knowledge_agent import (
+>>> from aieng.agent_evals.knowledge_qa import (
 ...     KnowledgeGroundedAgent,
 ...     DeepSearchQADataset,
 ...     DeepSearchQAEvaluator,

--- a/aieng-eval-agents/aieng/agent_evals/knowledge_qa/agent.py
+++ b/aieng-eval-agents/aieng/agent_evals/knowledge_qa/agent.py
@@ -241,7 +241,7 @@ class KnowledgeGroundedAgent:
 
     Examples
     --------
-    >>> from aieng.agent_evals.knowledge_agent import KnowledgeGroundedAgent
+    >>> from aieng.agent_evals.knowledge_qa import KnowledgeGroundedAgent
     >>> agent = KnowledgeGroundedAgent()
     >>> response = agent.answer("Who won the 2024 Nobel Prize in Physics?")
     >>> print(response.text)
@@ -283,7 +283,7 @@ class KnowledgeGroundedAgent:
 
         # Runner orchestrates the ReAct loop
         self._runner = Runner(
-            app_name="knowledge_agent",
+            app_name="knowledge_qa",
             agent=self._agent,
             session_service=self._session_service,
         )
@@ -310,7 +310,7 @@ class KnowledgeGroundedAgent:
         if session_id not in self._sessions:
             # Create a new ADK session through the session service
             session = await self._session_service.create_session(
-                app_name="knowledge_agent",
+                app_name="knowledge_qa",
                 user_id="user",
                 state={},
             )

--- a/aieng-eval-agents/aieng/agent_evals/knowledge_qa/evaluation.py
+++ b/aieng-eval-agents/aieng/agent_evals/knowledge_qa/evaluation.py
@@ -238,7 +238,7 @@ class DeepSearchQAEvaluator:
 
     Examples
     --------
-    >>> from aieng.agent_evals.knowledge_agent import (
+    >>> from aieng.agent_evals.knowledge_qa import (
     ...     KnowledgeGroundedAgent,
     ...     DeepSearchQAEvaluator,
     ... )

--- a/aieng-eval-agents/pyproject.toml
+++ b/aieng-eval-agents/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.scripts]
-knowledge-agent = "aieng.agent_evals.knowledge_agent.cli:main"
+knowledge-qa = "aieng.agent_evals.knowledge_qa.cli:main"
 
 [dependency-groups]
 dev = [

--- a/aieng-eval-agents/tests/aieng/agent_evals/knowledge_qa/test_agent.py
+++ b/aieng-eval-agents/tests/aieng/agent_evals/knowledge_qa/test_agent.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aieng.agent_evals.knowledge_agent.agent import (
+from aieng.agent_evals.knowledge_qa.agent import (
     SYSTEM_INSTRUCTIONS,
     KnowledgeAgentManager,
     KnowledgeGroundedAgent,
@@ -22,10 +22,10 @@ class TestKnowledgeGroundedAgent:
         config.default_worker_model = "gemini-2.5-flash"
         return config
 
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     def test_agent_initialization(
         self,
         mock_create_tool,
@@ -55,10 +55,10 @@ class TestKnowledgeGroundedAgent:
         mock_session_service.assert_called_once()
         mock_runner_class.assert_called_once()
 
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     def test_agent_with_custom_model(
         self,
         mock_create_tool,
@@ -74,10 +74,10 @@ class TestKnowledgeGroundedAgent:
         assert call_kwargs["model"] == "gemini-2.5-pro"
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_get_or_create_session(
         self,
         mock_create_tool,
@@ -110,10 +110,10 @@ class TestKnowledgeGroundedAgent:
         assert session3 != session1
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_get_or_create_session_generates_id(
         self,
         mock_create_tool,
@@ -136,10 +136,10 @@ class TestKnowledgeGroundedAgent:
         assert session is not None
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async(
         self,
         mock_create_tool,
@@ -176,10 +176,10 @@ class TestKnowledgeGroundedAgent:
         assert response.text == "Paris is the capital of France."
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_extracts_function_calls(
         self,
         mock_create_tool,
@@ -234,10 +234,10 @@ class TestKnowledgeGroundedAgent:
         assert "capital of France" in response.search_queries
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_extracts_sources_from_function_responses(
         self,
         mock_create_tool,
@@ -297,10 +297,10 @@ class TestKnowledgeGroundedAgent:
         assert response.sources[1].uri == "https://example.com/paris"
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_extracts_grounding_chunks_from_responses(
         self,
         mock_create_tool,
@@ -360,10 +360,10 @@ class TestKnowledgeGroundedAgent:
         assert response.sources[1].uri == "https://news.com/article"
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_extracts_grounding_metadata(
         self,
         mock_create_tool,
@@ -426,10 +426,10 @@ class TestKnowledgeGroundedAgent:
         assert "grounded query" in response.search_queries
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_extracts_grounding_metadata_from_content(
         self,
         mock_create_tool,
@@ -495,10 +495,10 @@ class TestKnowledgeGroundedAgent:
         assert "content query" in response.search_queries
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_handles_multiple_search_tool_names(
         self,
         mock_create_tool,
@@ -561,10 +561,10 @@ class TestKnowledgeGroundedAgent:
         assert "query three" in response.search_queries
 
     @pytest.mark.asyncio
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     async def test_answer_async_handles_empty_events(
         self,
         mock_create_tool,
@@ -618,10 +618,10 @@ class TestKnowledgeGroundedAgent:
 class TestKnowledgeAgentManager:
     """Tests for the KnowledgeAgentManager class."""
 
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     def test_lazy_initialization(
         self,
         mock_create_tool,
@@ -630,7 +630,7 @@ class TestKnowledgeAgentManager:
         mock_runner_class,
     ):
         """Test that clients are lazily initialized."""
-        with patch("aieng.agent_evals.knowledge_agent.agent.Configs") as mock_config_class:
+        with patch("aieng.agent_evals.knowledge_qa.agent.Configs") as mock_config_class:
             mock_config_class.return_value = MagicMock()
 
             manager = KnowledgeAgentManager()
@@ -644,10 +644,10 @@ class TestKnowledgeAgentManager:
             # Now should be initialized
             assert manager.is_initialized()
 
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     def test_close(
         self,
         mock_create_tool,
@@ -656,7 +656,7 @@ class TestKnowledgeAgentManager:
         mock_runner_class,
     ):
         """Test closing the client manager."""
-        with patch("aieng.agent_evals.knowledge_agent.agent.Configs") as mock_config_class:
+        with patch("aieng.agent_evals.knowledge_qa.agent.Configs") as mock_config_class:
             mock_config_class.return_value = MagicMock()
 
             manager = KnowledgeAgentManager()
@@ -666,10 +666,10 @@ class TestKnowledgeAgentManager:
             manager.close()
             assert not manager.is_initialized()
 
-    @patch("aieng.agent_evals.knowledge_agent.agent.Runner")
-    @patch("aieng.agent_evals.knowledge_agent.agent.InMemorySessionService")
-    @patch("aieng.agent_evals.knowledge_agent.agent.Agent")
-    @patch("aieng.agent_evals.knowledge_agent.agent.create_google_search_tool")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Runner")
+    @patch("aieng.agent_evals.knowledge_qa.agent.InMemorySessionService")
+    @patch("aieng.agent_evals.knowledge_qa.agent.Agent")
+    @patch("aieng.agent_evals.knowledge_qa.agent.create_google_search_tool")
     def test_agent_reuse(
         self,
         mock_create_tool,
@@ -678,7 +678,7 @@ class TestKnowledgeAgentManager:
         mock_runner_class,
     ):
         """Test that agent is reused on multiple accesses."""
-        with patch("aieng.agent_evals.knowledge_agent.agent.Configs") as mock_config_class:
+        with patch("aieng.agent_evals.knowledge_qa.agent.Configs") as mock_config_class:
             mock_config_class.return_value = MagicMock()
 
             manager = KnowledgeAgentManager()
@@ -698,7 +698,7 @@ class TestKnowledgeGroundedAgentIntegration:
 
     def test_agent_creation_real(self):
         """Test creating a real agent instance."""
-        from aieng.agent_evals.knowledge_agent import (  # noqa: PLC0415
+        from aieng.agent_evals.knowledge_qa import (  # noqa: PLC0415
             KnowledgeGroundedAgent,
         )
 
@@ -709,7 +709,7 @@ class TestKnowledgeGroundedAgentIntegration:
     @pytest.mark.asyncio
     async def test_answer_real_question(self):
         """Test answering a real question."""
-        from aieng.agent_evals.knowledge_agent import (  # noqa: PLC0415
+        from aieng.agent_evals.knowledge_qa import (  # noqa: PLC0415
             KnowledgeGroundedAgent,
         )
 

--- a/aieng-eval-agents/tests/aieng/agent_evals/knowledge_qa/test_evaluation.py
+++ b/aieng-eval-agents/tests/aieng/agent_evals/knowledge_qa/test_evaluation.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
-from aieng.agent_evals.knowledge_agent.evaluation import (
+from aieng.agent_evals.knowledge_qa.evaluation import (
     DeepSearchQADataset,
     DSQAExample,
     EvaluationResult,
@@ -78,8 +78,8 @@ class TestDeepSearchQADataset:
             "answer_type": ["Single Answer", "List", "Single Answer"],
         }
 
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.kagglehub.dataset_download")
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.pd.read_csv")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.kagglehub.dataset_download")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.pd.read_csv")
     def test_dataset_loading(self, mock_read_csv, mock_download, mock_csv_data):
         """Test loading the dataset."""
         mock_download.return_value = "/fake/path"
@@ -92,8 +92,8 @@ class TestDeepSearchQADataset:
         assert len(examples) == 3
         assert examples[0].problem == "Q1"
 
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.kagglehub.dataset_download")
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.pd.read_csv")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.kagglehub.dataset_download")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.pd.read_csv")
     def test_dataset_length(self, mock_read_csv, mock_download, mock_csv_data):
         """Test getting dataset length."""
         mock_download.return_value = "/fake/path"
@@ -103,8 +103,8 @@ class TestDeepSearchQADataset:
             dataset = DeepSearchQADataset()
             assert len(dataset) == 3
 
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.kagglehub.dataset_download")
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.pd.read_csv")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.kagglehub.dataset_download")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.pd.read_csv")
     def test_dataset_indexing(self, mock_read_csv, mock_download, mock_csv_data):
         """Test indexing into the dataset."""
         mock_download.return_value = "/fake/path"
@@ -117,8 +117,8 @@ class TestDeepSearchQADataset:
         assert example.example_id == 1
         assert example.problem == "Q2"
 
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.kagglehub.dataset_download")
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.pd.read_csv")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.kagglehub.dataset_download")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.pd.read_csv")
     def test_get_by_category(self, mock_read_csv, mock_download, mock_csv_data):
         """Test filtering by category."""
         mock_download.return_value = "/fake/path"
@@ -131,8 +131,8 @@ class TestDeepSearchQADataset:
         assert len(cat_a_examples) == 2
         assert all(ex.problem_category == "Cat A" for ex in cat_a_examples)
 
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.kagglehub.dataset_download")
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.pd.read_csv")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.kagglehub.dataset_download")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.pd.read_csv")
     def test_get_categories(self, mock_read_csv, mock_download, mock_csv_data):
         """Test getting unique categories."""
         mock_download.return_value = "/fake/path"
@@ -145,8 +145,8 @@ class TestDeepSearchQADataset:
         assert "Cat A" in categories
         assert "Cat B" in categories
 
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.kagglehub.dataset_download")
-    @patch("aieng.agent_evals.knowledge_agent.evaluation.pd.read_csv")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.kagglehub.dataset_download")
+    @patch("aieng.agent_evals.knowledge_qa.evaluation.pd.read_csv")
     def test_sample(self, mock_read_csv, mock_download, mock_csv_data):
         """Test random sampling."""
         mock_download.return_value = "/fake/path"

--- a/implementations/knowledge_qa/01_grounding_basics.ipynb
+++ b/implementations/knowledge_qa/01_grounding_basics.ipynb
@@ -22,7 +22,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Setup: Load environment and configure rich console\nfrom aieng.agent_evals import (\n    create_console,\n    display_comparison,\n    display_response,\n    display_source_table,\n)\nfrom aieng.agent_evals.knowledge_agent import KnowledgeAgentConfig, KnowledgeGroundedAgent\nfrom dotenv import load_dotenv\nfrom google import genai\nfrom rich.panel import Panel\n\n\nconsole = create_console()\nload_dotenv(verbose=True)"
+   "source": "# Setup: Load environment and configure rich console\nfrom aieng.agent_evals import (\n    create_console,\n    display_comparison,\n    display_response,\n    display_source_table,\n)\nfrom aieng.agent_evals.knowledge_qa import KnowledgeAgentConfig, KnowledgeGroundedAgent\nfrom dotenv import load_dotenv\nfrom google import genai\nfrom rich.panel import Panel\n\n\nconsole = create_console()\nload_dotenv(verbose=True)"
   },
   {
    "cell_type": "markdown",

--- a/implementations/knowledge_qa/02_agent_basics.ipynb
+++ b/implementations/knowledge_qa/02_agent_basics.ipynb
@@ -22,7 +22,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Setup: Load environment and configure rich console\nfrom aieng.agent_evals import (\n    create_console,\n    display_example,\n    display_info,\n    display_response,\n    display_success,\n)\nfrom aieng.agent_evals.knowledge_agent import (\n    DeepSearchQADataset,\n    KnowledgeAgentManager,\n    KnowledgeGroundedAgent,\n)\nfrom aieng.agent_evals.knowledge_agent.agent import SYSTEM_INSTRUCTIONS\nfrom dotenv import load_dotenv\nfrom rich.markdown import Markdown\nfrom rich.panel import Panel\nfrom rich.table import Table\n\n\nconsole = create_console()\nload_dotenv(verbose=True)"
+   "source": "# Setup: Load environment and configure rich console\nfrom aieng.agent_evals import (\n    create_console,\n    display_example,\n    display_info,\n    display_response,\n    display_success,\n)\nfrom aieng.agent_evals.knowledge_qa import (\n    DeepSearchQADataset,\n    KnowledgeAgentManager,\n    KnowledgeGroundedAgent,\n)\nfrom aieng.agent_evals.knowledge_qa.agent import SYSTEM_INSTRUCTIONS\nfrom dotenv import load_dotenv\nfrom rich.markdown import Markdown\nfrom rich.panel import Panel\nfrom rich.table import Table\n\n\nconsole = create_console()\nload_dotenv(verbose=True)"
   },
   {
    "cell_type": "markdown",

--- a/implementations/knowledge_qa/03_multi_turn.ipynb
+++ b/implementations/knowledge_qa/03_multi_turn.ipynb
@@ -20,7 +20,7 @@
     "    display_metrics_table,\n",
     "    display_success,\n",
     ")\n",
-    "from aieng.agent_evals.knowledge_agent import (\n",
+    "from aieng.agent_evals.knowledge_qa import (\n",
     "    DeepSearchQADataset,\n",
     "    DeepSearchQAEvaluator,\n",
     "    KnowledgeGroundedAgent,\n",

--- a/implementations/knowledge_qa/README.md
+++ b/implementations/knowledge_qa/README.md
@@ -41,13 +41,13 @@ uv sync
 Run the Gradio app:
 
 ```bash
-uv run --env-file .env gradio implementations/knowledge_agent/gradio_app.py
+uv run --env-file .env gradio implementations/knowledge_qa/gradio_app.py
 ```
 
 ### Programmatic Usage
 
 ```python
-from aieng.agent_evals.knowledge_agent import KnowledgeGroundedAgent
+from aieng.agent_evals.knowledge_qa import KnowledgeGroundedAgent
 
 agent = KnowledgeGroundedAgent()
 
@@ -65,7 +65,7 @@ print(f"Tool calls: {response.tool_calls}")
 ### Evaluation on DeepSearchQA
 
 ```python
-from aieng.agent_evals.knowledge_agent import (
+from aieng.agent_evals.knowledge_qa import (
     KnowledgeGroundedAgent,
     DeepSearchQAEvaluator,
 )
@@ -90,7 +90,7 @@ print(df[["example_id", "ground_truth", "prediction", "sources_used"]])
 ## Architecture
 
 ```
-aieng.agent_evals.knowledge_agent/
+aieng.agent_evals.knowledge_qa/
 ├── config.py          # Configuration (Pydantic settings)
 ├── grounding_tool.py  # GoogleSearchTool wrapper and response models
 ├── agent.py           # KnowledgeGroundedAgent (ADK Agent + Runner)

--- a/implementations/knowledge_qa/gradio_app.py
+++ b/implementations/knowledge_qa/gradio_app.py
@@ -4,7 +4,7 @@ This app provides an interactive chat interface for testing the
 knowledge-grounded QA agent with Google ADK and explicit Google Search tool calls.
 
 Run with:
-    uv run --env-file .env gradio implementations/knowledge_agent/gradio_app.py
+    uv run --env-file .env gradio implementations/knowledge_qa/gradio_app.py
 """
 
 import asyncio
@@ -13,7 +13,7 @@ import uuid
 from typing import Any, Generator
 
 import gradio as gr
-from aieng.agent_evals.knowledge_agent import (
+from aieng.agent_evals.knowledge_qa import (
     DeepSearchQADataset,
     KnowledgeAgentManager,
 )


### PR DESCRIPTION
- Renaming the implementation and sub-package to `knowledge_qa` which is more aligned with the naming convention of the other implementations, i.e. remove "agent"