### PR TITLE
Bump onboard package to 0.6.2 with updates

### DIFF
--- a/aieng-eval-agents/pyproject.toml
+++ b/aieng-eval-agents/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 dependencies = [
     "google-adk>=1.23.0",
     "google-genai>=1.52.0",
-    "gradio>=6.0.2",
+    "gradio>=6.7.0", # CVE-2026-28414/27167/28416/28415 fixed in 6.6.0–6.7.0
     "kagglehub>=0.4.1",
     "langfuse>=3.10.3",
     "openai>=2.8.1",
@@ -24,7 +24,7 @@ dependencies = [
     "sqlalchemy>=2.0.46",
     "sqlglot>=28.6.0",
     "weaviate-client>=4.18.3",
-    "pypdf",
+    "pypdf>=6.7.5", # CVE-2026-28804: ASCIIHexDecode DoS fixed in 6.7.5
     "httpx>=0.27.0",
     "tenacity>=8.2.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,18 @@ dependencies = [
     "scikit-learn>=1.7.0",
     "urllib3>=2.6.3",
     "openpyxl>=3.1.5",
-    "authlib>=1.6.6",
+    "authlib>=1.6.7", # CVE-2026-28802: alg:none JWT bypass fixed in 1.6.7
     "filelock>=3.20.3",
     "pyasn1>=0.6.2",
     "virtualenv>=20.36.1",
     "tenacity>=9.1.2",
     "certifi>=2026.1.4",
-    "pypdf>=6.7.3",
+    "pypdf>=6.7.5", # CVE-2026-28804: ASCIIHexDecode DoS fixed in 6.7.5
 ]
 
 [dependency-groups]
 dev = [
-    "aieng-platform-onboard>=0.6.0",
+    "aieng-platform-onboard>=0.6.2",
     "mypy>=1.19.0",
     "codecov>=2.1.13",
     "ipykernel>=7.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ web-search = [
 requires-dist = [
     { name = "aieng-eval-agents", editable = "aieng-eval-agents" },
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "authlib", specifier = ">=1.6.6" },
+    { name = "authlib", specifier = ">=1.6.7" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "certifi", specifier = ">=2026.1.4" },
     { name = "datasets", specifier = ">=3.6.0" },
@@ -105,7 +105,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pydantic-ai-slim", extras = ["logfire"], specifier = ">=1.26.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
-    { name = "pypdf", specifier = ">=6.7.3" },
+    { name = "pypdf", specifier = ">=6.7.5" },
     { name = "scikit-learn", specifier = ">=1.7.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "urllib3", specifier = ">=2.6.3" },
@@ -114,7 +114,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aieng-platform-onboard", specifier = ">=0.6.0" },
+    { name = "aieng-platform-onboard", specifier = ">=0.6.2" },
     { name = "codecov", specifier = ">=2.1.13" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "ipython", specifier = ">=9.8.0" },
@@ -190,7 +190,7 @@ dev = [
 requires-dist = [
     { name = "google-adk", specifier = ">=1.23.0" },
     { name = "google-genai", specifier = ">=1.52.0" },
-    { name = "gradio", specifier = ">=6.0.2" },
+    { name = "gradio", specifier = ">=6.7.0" },
     { name = "html-to-markdown", specifier = ">=2.24.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "kagglehub", specifier = ">=0.4.1" },
@@ -203,7 +203,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
-    { name = "pypdf" },
+    { name = "pypdf", specifier = ">=6.7.5" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.9.0" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
@@ -221,7 +221,7 @@ dev = [
 
 [[package]]
 name = "aieng-platform-onboard"
-version = "0.6.0"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -241,9 +241,9 @@ dependencies = [
     { name = "virtualenv" },
     { name = "weaviate-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/b6/57cd7a3c54c1a6216a4d155d6a7e82180e9f161b3feba8c40fc6702ebd31/aieng_platform_onboard-0.6.0.tar.gz", hash = "sha256:2965471b2b5aef7f2950639d8af2759307dc9b883b26846c53b3c3865954657e", size = 34820 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/26/2b12be7378936e82d861a360a03f9daf43efd094cdf87e1d5f4beef0dbb4/aieng_platform_onboard-0.6.2.tar.gz", hash = "sha256:e4cc9852afcbe926daf041a63fb190def585f3f816a39f06c17f431be2e71719", size = 34846 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/c0/37bc8641350377e003f260778dcd037f1e961417db7ea7bb20060c89e96c/aieng_platform_onboard-0.6.0-py3-none-any.whl", hash = "sha256:9693568104f6ba48b7850e27b7cc4a3e46db0a7d7117136732864cc49388b413", size = 42287 },
+    { url = "https://files.pythonhosted.org/packages/1d/70/2dc99e9dcdaf4c145d5fba415c7334ec9432b3f5dc51d54d87ba934de8ab/aieng_platform_onboard-0.6.2-py3-none-any.whl", hash = "sha256:2cff687d0381914de4917ad51e5e5efe04ec7a667426cb653f56ea3956c7b701", size = 42306 },
 ]
 
 [[package]]
@@ -566,14 +566,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.6"
+version = "1.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/dc/ed1681bf1339dd6ea1ce56136bad4baabc6f7ad466e375810702b0237047/authlib-1.6.7.tar.gz", hash = "sha256:dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b", size = 164950 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005 },
+    { url = "https://files.pythonhosted.org/packages/f8/00/3ed12264094ec91f534fae429945efbaa9f8c666f3aa7061cc3b2a26a0cd/authlib-1.6.7-py2.py3-none-any.whl", hash = "sha256:c637340d9a02789d2efa1d003a7437d10d3e565237bcb5fcbc6c134c7b95bab0", size = 244115 },
 ]
 
 [[package]]
@@ -2102,7 +2102,7 @@ grpc = [
 
 [[package]]
 name = "gradio"
-version = "6.5.1"
+version = "6.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2135,14 +2135,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/4f/b095b9a9ddc1ba433121f390df0e8a20a3360ffabd43ec13e86d6ce412b4/gradio-6.5.1.tar.gz", hash = "sha256:31223a1699f15072176dbf48a94f08457228a38263bb4c221a0ccea3a639a595", size = 40132899 }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/83/29bdbf94b212512e3c775482d390f5b699a72d71a2c431dea367a6e45a37/gradio-6.9.0.tar.gz", hash = "sha256:593e60e33233f3586452ebfa9f741817c5ae849a98cc70945f3ccb8dc895eb22", size = 57904480 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/72/4f56a920147ce215e2286defc257a613b3b6d8c90cea323758a99ca0f9fa/gradio-6.5.1-py3-none-any.whl", hash = "sha256:5d49ff9691413ca5411189a694de5cbf1b171e2d49bf9f113952ae8a93c7088d", size = 24183125 },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/dc357ab966544e4dc898a2fee326d755c5f54da82af71a1a802e3476e78e/gradio-6.9.0-py3-none-any.whl", hash = "sha256:c173dd330c9247002a42222c85d76c0ecee65437eff808084e360862e7bbd24f", size = 42940853 },
 ]
 
 [[package]]
 name = "gradio-client"
-version = "2.0.3"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
@@ -2151,9 +2151,9 @@ dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/75/5c971cc80a6a477f038c66869178684c5010fd61b232277c120c61588d74/gradio_client-2.0.3.tar.gz", hash = "sha256:8f1cec02dccaf64ac0285ed60479a2b0db3778dfe74c85a36d7ec9a95daeccc4", size = 55027 }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d2/de2037f5eff13a5145cdf6982fd34c9735f0806e8a2ee5d4bfe9a7d25a54/gradio_client-2.3.0.tar.gz", hash = "sha256:1c700dc60e65bae4386ba7cf3732b9f9d5bcf5fb8eb451df3944fe092d7d9a29", size = 57552 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/11/758b76a14e1783549c71828b36e81c997b99683bc4ec14b28417dff3348f/gradio_client-2.0.3-py3-none-any.whl", hash = "sha256:bcc88da74e3a387bcd41535578abbafe2091bcf4715c9542111804741b9e50b0", size = 55669 },
+    { url = "https://files.pythonhosted.org/packages/99/6a/41752781399811afbf8ac858f63c20eff354ed35169daa39604aefced4e8/gradio_client-2.3.0-py3-none-any.whl", hash = "sha256:9ec51a927888fc188e123a0ac5ad341d9265b325539a399554d1fc2604942e74", size = 58531 },
 ]
 
 [[package]]
@@ -5023,11 +5023,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.7.4"
+version = "6.7.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/dc/f52deef12797ad58b88e4663f097a343f53b9361338aef6573f135ac302f/pypdf-6.7.4.tar.gz", hash = "sha256:9edd1cd47938bb35ec87795f61225fd58a07cfaf0c5699018ae1a47d6f8ab0e3", size = 5304821 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/52/37cc0aa9e9d1bf7729a737a0d83f8b3f851c8eb137373d9f71eafb0a3405/pypdf-6.7.5.tar.gz", hash = "sha256:40bb2e2e872078655f12b9b89e2f900888bb505e88a82150b64f9f34fa25651d", size = 5304278 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/be/cded021305f5c81b47265b8c5292b99388615a4391c21ff00fd538d34a56/pypdf-6.7.4-py3-none-any.whl", hash = "sha256:527d6da23274a6c70a9cb59d1986d93946ba8e36a6bc17f3f7cce86331492dda", size = 331496 },
+    { url = "https://files.pythonhosted.org/packages/05/89/336673efd0a88956562658aba4f0bbef7cb92a6fbcbcaf94926dbc82b408/pypdf-6.7.5-py3-none-any.whl", hash = "sha256:07ba7f1d6e6d9aa2a17f5452e320a84718d4ce863367f7ede2fd72280349ab13", size = 331421 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates several dependencies in both `pyproject.toml` and `aieng-eval-agents/pyproject.toml` to address recent security vulnerabilities (CVEs) and ensure the project uses secure, patched versions of its libraries.

Dependency security updates:

* Upgraded `gradio` to version `>=6.7.0` in `aieng-eval-agents/pyproject.toml` to address multiple CVEs (CVE-2026-28414, CVE-2026-27167, CVE-2026-28416, CVE-2026-28415) that were fixed in versions 6.6.0–6.7.0.
* Upgraded `pypdf` to version `>=6.7.5` in both `pyproject.toml` and `aieng-eval-agents/pyproject.toml` to fix CVE-2026-28804 (ASCIIHexDecode DoS vulnerability). [[1]](diffhunk://#diff-61f4d8554965313e4acbfab24e130e600c3952038834f3014a8cedec6c974f8dL27-R27) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L26-R37)
* Upgraded `authlib` to version `>=1.6.7` in `pyproject.toml` to fix CVE-2026-28802 (alg:none JWT bypass vulnerability).

Development dependency update:

* Upgraded `aieng-platform-onboard` to version `>=0.6.2` in the development dependencies group in `pyproject.toml`.