### PR TITLE
Better error messages on SQL client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ GOOGLE_API_KEY="..." # Used by google-adk
 
 # Model selection (see https://ai.google.dev/gemini-api/docs/models)
 # Stable: gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite
-# Preview: gemini-3-pro-preview, gemini-3-flash-preview
+# Preview: gemini-3.1-pro-preview, gemini-3.1-flash-preview
 DEFAULT_PLANNER_MODEL="gemini-2.5-pro"
 DEFAULT_WORKER_MODEL="gemini-2.5-flash"
 DEFAULT_EVALUATOR_MODEL="gemini-2.5-pro"

--- a/aieng-eval-agents/aieng/agent_evals/tools/sql_database.py
+++ b/aieng-eval-agents/aieng/agent_evals/tools/sql_database.py
@@ -166,9 +166,9 @@ class ReadOnlySqlDatabase:
 
             return is_safe
         except Exception as e:
-            logger.error("SQL Parsing Error: %s", e)
+            logger.exception("SQL Parsing Error: %s", e)
             # If we can't parse it, we don't run it.
-            return False
+            raise e
 
     def get_schema_info(self, table_names: Optional[list[str]] = None) -> str:
         """Return schema for specific tables/views or all if None.
@@ -296,6 +296,7 @@ class ReadOnlySqlDatabase:
                 return "\n".join(output)
 
         except Exception as e:
+            logger.exception("Error executing query: %s", e)
             error_msg = str(e)
             return f"Query Error: {error_msg}"
 

--- a/aieng-eval-agents/tests/aieng/agent_evals/tools/test_sql_database.py
+++ b/aieng-eval-agents/tests/aieng/agent_evals/tools/test_sql_database.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+import sqlglot
 from aieng.agent_evals.tools import ReadOnlySqlDatabase, ReadOnlySqlPolicy, sql_database
 from sqlalchemy import create_engine
 
@@ -154,13 +155,11 @@ def test_is_safe_readonly_query_blocks_forbidden_nodes_even_if_root_is_allowed(s
     assert db._is_safe_readonly_query("DELETE FROM customers") is False
 
 
-def test_is_safe_readonly_query_returns_false_on_parse_errors(
-    sqlite_db_uri: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Return False (fail closed) if parsing raises."""
-    db = ReadOnlySqlDatabase(connection_uri=sqlite_db_uri)
-    monkeypatch.setattr("aieng.agent_evals.tools.sql_database.sqlglot.parse", lambda _query: 1 / 0)
-    assert db._is_safe_readonly_query("SELECT 1") is False
+def test_is_safe_readonly_query_returns_exception_on_parse_errors(sqlite_db_uri: str) -> None:
+    """Return exception if parsing raises an exception."""
+    with pytest.raises(sqlglot.errors.ParseError):
+        db = ReadOnlySqlDatabase(connection_uri=sqlite_db_uri)
+        assert db._is_safe_readonly_query("SERECT 1") is False
 
 
 def test_get_schema_info_includes_tables_and_views(default_db: ReadOnlySqlDatabase) -> None:


### PR DESCRIPTION
## Summary

Raising error on SQL internal method instead of returning `False` to provide better error messages to the agents. Also:
- Adding exception logging for better debugging by the devs
- Updating `.env.example` to have the Gemini 3.1 models names because Gemini 3 has been deprecated.

Clickup Ticket(s): NA
## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔒 Security fix

## Changes Made

- Raising error on SQL internal method instead of returning `False` to provide better error messages to the agents
- Adding exception logging for better debugging by the devs
- Updating `.env.example` to have the Gemini 3.1 models names because Gemini 3 has been deprecated.

## Testing

<!-- Describe how you tested these changes -->
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Type checking passes (`uv run mypy <src_dir>`)
- [ ] Linting passes (`uv run ruff check src_dir/`)
- [ ] Manual testing performed (describe below)

**Manual testing details:**
<!-- Describe any manual testing performed -->

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

## Related Issues

<!-- Link any related issues using "Closes #123" or "Relates to #123" -->

## Deployment Notes

<!-- Any special deployment considerations or migration steps -->

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code completed
- [ ] Documentation updated (if applicable)
- [ ] No sensitive information (API keys, credentials) exposed
